### PR TITLE
Add Playwright e2e tests 🎭

### DIFF
--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -150,15 +150,11 @@ jobs:
         with:
           node-version: "14.x"
 
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Run Playwright tests
         run: |
           npm ci
-          npx playwright install --with-deps
-          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ needs.build.outputs.apiUrl }} HOME=/root npx playwright test
+          npx playwright install
+          baseUrl=${{ needs.deploy.outputs.baseUrl }} apiUrl=${{ needs.deploy.outputs.apiUrl }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -153,16 +153,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Get container app FQDN's'
-        uses: azure/powershell@v1
-        with:
-          azPSVersion: "latest"
-          inlineScript: |
-            az extension add --name containerapp
-            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
-            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
-            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-
       - name: Run Playwright tests
         run: |
           npm ci

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -143,6 +143,7 @@ jobs:
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:
+          azPSVersion: 'latest'
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -140,6 +140,7 @@ jobs:
     needs: deploy
     timeout-minutes: 60
     runs-on: ubuntu-22.04
+    container: mcr.microsoft.com/playwright:v1.28.1-focal
     defaults:
       run:
         working-directory: e2e-tests

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -141,7 +141,7 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/CLI@v1
+        uses: azure/powershell@v1
         with:
           inlineScript: |
             az extension add --name containerapp

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -157,7 +157,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps
-          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ ${{ needs.build.outputs.apiUrl }} }} HOME=/root npx playwright test
+          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ needs.build.outputs.apiUrl }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -159,12 +159,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: e2e-tests/test-results/junit.xml
+          paths: test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: e2e-tests/playwright-report/
+          path: playwright-report/
           retention-days: 30

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -160,12 +160,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: test-results/junit.xml
+          paths: ./test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: ./playwright-report/html
           retention-days: 30

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -139,9 +139,8 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/powershell@v1
+        uses: azure/powershell@v3
         with:
-          azPSVersion: "latest"
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -97,6 +97,9 @@ jobs:
   deploy:
     if: github.repository != 'Azure-samples/containerapps-dapralbums'
     runs-on: ubuntu-latest
+    concurrency:
+      group: dev
+      cancel-in-progress: true
     needs: [package-services]
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -160,12 +160,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: ./test-results/junit.xml
+          paths: e2e-tests/test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: ./playwright-report/html
+          path: e2e-tests/playwright-report/html
           retention-days: 30

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -140,6 +140,10 @@ jobs:
           npm ci
           npx playwright install
 
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -118,3 +118,50 @@ jobs:
             registryServer=${{ env.REGISTRY }} \
             registryUsername=${{ github.actor }} \
             registryPassword=${{ secrets.GH_PAT }}
+
+  test:
+    needs: deploy
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.28.1-focal
+    defaults:
+      run:
+        working-directory: e2e-tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install
+
+      - name: Get container app FQDN's'
+        uses: azure/powershell@v1
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            az extension add --name containerapp
+            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
+            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
+            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        
+      - name: Run Playwright tests
+        run: |
+          baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
+
+      - name: Create test summary
+        uses: test-summary/action@dist
+        if: always()
+        with:
+          paths: src/Web/E2E/test-results/junit.xml
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: playwright-report
+          path: src/Web/E2E/playwright-report/
+          retention-days: 30

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -135,11 +135,6 @@ jobs:
         with:
           node-version: "14.x"
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          npx playwright install
-
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -156,6 +151,8 @@ jobs:
 
       - name: Run Playwright tests
         run: |
+          npm ci
+          npx playwright install --with-deps
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
 
       - name: Create test summary

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -122,6 +122,20 @@ jobs:
             registryUsername=${{ github.actor }} \
             registryPassword=${{ secrets.GH_PAT }}
 
+      - name: Get container app FQDN's'
+        uses: azure/powershell@v1
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            az extension add --name containerapp
+            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
+            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
+            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
+    outputs:
+      baseUrl: ${{ env.BASE_URL }}
+      apiUrl: ${{ env.API_URL }}            
+
   test:
     needs: deploy
     timeout-minutes: 60
@@ -153,7 +167,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps
-          baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
+          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ ${{ needs.build.outputs.apiUrl }} }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -159,12 +159,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: src/Web/E2E/test-results/junit.xml
+          paths: e2e-tests/test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: src/Web/E2E/playwright-report/
+          path: e2e-tests/playwright-report/
           retention-days: 30

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -125,8 +125,7 @@ jobs:
   test:
     needs: deploy
     timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.28.1-focal
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: e2e-tests

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -142,7 +142,7 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/powershell@v3
+        uses: azure/CLI@v1
         with:
           inlineScript: |
             az extension add --name containerapp

--- a/.github/workflows/build-and-push-dev.yaml
+++ b/.github/workflows/build-and-push-dev.yaml
@@ -143,17 +143,17 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-          
+
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:
-          azPSVersion: 'latest'
+          azPSVersion: "latest"
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
             $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_DEV}} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
             echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-        
+
       - name: Run Playwright tests
         run: |
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -150,15 +150,11 @@ jobs:
         with:
           node-version: "14.x"
 
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Run Playwright tests
         run: |
           npm ci
-          npx playwright install --with-deps
-          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ needs.build.outputs.apiUrl }} HOME=/root npx playwright test
+          npx playwright install
+          baseUrl=${{ needs.deploy.outputs.baseUrl }} apiUrl=${{ needs.deploy.outputs.apiUrl }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -139,9 +139,8 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/powershell@v1
+        uses: azure/powershell@v3
         with:
-          azPSVersion: "latest"
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -122,10 +122,25 @@ jobs:
             registryUsername=${{ github.actor }} \
             registryPassword=${{ secrets.GH_PAT }}
 
+      - name: Get container app FQDN's'
+        uses: azure/powershell@v1
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            az extension add --name containerapp
+            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
+            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
+            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
+    outputs:
+      baseUrl: ${{ env.BASE_URL }}
+      apiUrl: ${{ env.API_URL }}
+
   test:
     needs: deploy
     timeout-minutes: 60
     runs-on: ubuntu-22.04
+    container: mcr.microsoft.com/playwright:v1.28.1-focal
     defaults:
       run:
         working-directory: e2e-tests
@@ -139,21 +154,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Get container app FQDN's'
-        uses: azure/powershell@v1
-        with:
-          azPSVersion: "latest"
-          inlineScript: |
-            az extension add --name containerapp
-            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
-            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
-            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-
       - name: Run Playwright tests
         run: |
           npm ci
           npx playwright install --with-deps
-          baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
+          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ ${{ needs.build.outputs.apiUrl }} }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -125,7 +125,7 @@ jobs:
   test:
     needs: deploy
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: mcr.microsoft.com/playwright:v1.28.1-focal
     defaults:
       run:
@@ -142,7 +142,7 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/CLI@v1
+        uses: azure/powershell@v1
         with:
           inlineScript: |
             az extension add --name containerapp

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -160,12 +160,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: src/Web/E2E/test-results/junit.xml
+          paths: test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: src/Web/E2E/playwright-report/
+          path: playwright-report/
           retention-days: 30

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -160,12 +160,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: test-results/junit.xml
+          paths: ./test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: ./playwright-report/html
           retention-days: 30

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -160,12 +160,12 @@ jobs:
         uses: test-summary/action@dist
         if: always()
         with:
-          paths: ./test-results/junit.xml
+          paths: e2e-tests/test-results/junit.xml
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: playwright-report
-          path: ./playwright-report/html
+          path: e2e-tests/playwright-report/html
           retention-days: 30

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -140,6 +140,10 @@ jobs:
           npm ci
           npx playwright install
 
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -158,7 +158,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps
-          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ ${{ needs.build.outputs.apiUrl }} }} HOME=/root npx playwright test
+          baseUrl=${{ needs.build.outputs.baseUrl }} apiUrl=${{ needs.build.outputs.apiUrl }} HOME=/root npx playwright test
 
       - name: Create test summary
         uses: test-summary/action@dist

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -138,12 +138,12 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npx playwright install
-
+          npx playwright install --with-deps
+          
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-          
+
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:
@@ -156,6 +156,7 @@ jobs:
         
       - name: Run Playwright tests
         run: |
+          npx playwright install 
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
 
       - name: Create test summary

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -135,11 +135,6 @@ jobs:
         with:
           node-version: "14.x"
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          npx playwright install --with-deps
-
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -156,6 +151,8 @@ jobs:
 
       - name: Run Playwright tests
         run: |
+          npm ci
+          npx playwright install --with-deps
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
 
       - name: Create test summary

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -97,6 +97,9 @@ jobs:
   deploy:
     if: github.repository != 'Azure-samples/containerapps-dapralbums'
     runs-on: ubuntu-latest
+    concurrency:
+      group: prod
+      cancel-in-progress: true    
     needs: [package-services]
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -118,3 +118,50 @@ jobs:
             registryServer=${{ env.REGISTRY }} \
             registryUsername=${{ github.actor }} \
             registryPassword=${{ secrets.GH_PAT }}
+
+  test:
+    needs: deploy
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.28.1-focal
+    defaults:
+      run:
+        working-directory: e2e-tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install
+
+      - name: Get container app FQDN's'
+        uses: azure/powershell@v1
+        with:
+          azPSVersion: "latest"
+          inlineScript: |
+            az extension add --name containerapp
+            $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
+            $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
+            echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        
+      - name: Run Playwright tests
+        run: |
+          baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
+
+      - name: Create test summary
+        uses: test-summary/action@dist
+        if: always()
+        with:
+          paths: src/Web/E2E/test-results/junit.xml
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: playwright-report
+          path: src/Web/E2E/playwright-report/
+          retention-days: 30

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -139,7 +139,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps
-          
+
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -156,7 +156,6 @@ jobs:
         
       - name: Run Playwright tests
         run: |
-          npx playwright install 
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test
 
       - name: Create test summary

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -126,7 +126,6 @@ jobs:
     needs: deploy
     timeout-minutes: 60
     runs-on: ubuntu-22.04
-    container: mcr.microsoft.com/playwright:v1.28.1-focal
     defaults:
       run:
         working-directory: e2e-tests
@@ -144,6 +143,7 @@ jobs:
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:
+          azPSVersion: 'latest'
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: prod
-      cancel-in-progress: true    
+      cancel-in-progress: true
     needs: [package-services]
     steps:
       - name: Checkout repository
@@ -147,13 +147,13 @@ jobs:
       - name: Get container app FQDN's'
         uses: azure/powershell@v1
         with:
-          azPSVersion: 'latest'
+          azPSVersion: "latest"
           inlineScript: |
             az extension add --name containerapp
             $baseUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-viewer -o tsv --query properties.configuration.ingress.fqdn)"
             $apiUrl = "https://$(az containerapp show -g ${{ secrets.RG_PROD }} -n album-api -o tsv --query properties.configuration.ingress.fqdn)"
             echo "BASE_URL=$baseUrl" "API_URL=$apiUrl" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-        
+
       - name: Run Playwright tests
         run: |
           baseUrl=${{ env.BASE_URL }} apiUrl=${{ env.API_URL }} HOME=/root npx playwright test

--- a/.github/workflows/build-and-push-prod.yaml
+++ b/.github/workflows/build-and-push-prod.yaml
@@ -142,7 +142,7 @@ jobs:
           npx playwright install
 
       - name: Get container app FQDN's'
-        uses: azure/powershell@v3
+        uses: azure/CLI@v1
         with:
           inlineScript: |
             az extension add --name containerapp

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ The entire solution is configured with [GitHub Actions](https://github.com/featu
    | Name | Value |
    | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
    | AZURE_CREDENTIALS | The JSON credentials for an Azure subscription. Replace the placeholder values and run the following command to generate the Azure authentication information for this GitHub secret `az ad sp create-for-rbac --name INSERT_SP_NAME --role contributor --scopes /subscriptions/INSERT_SUBSCRIPTION_ID --sdk-auth`. For guidance on adding a secret, [see here](https://docs.microsoft.com/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#create-a-service-principal-and-add-it-as-a-github-secret) |
-   | RESOURCE_GROUP | The name of the resource group to create |
+   | RG_DEV | The name of the resource group to create for a Development environment |
+   | RG_PROD (optional) | The name of the resource group to create for a Production environment |   
    | GH_PAT | [Generate a GitHub personal access token with `write:packages` permission](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and store as a pipeline secret. This PAT will be used to push images to your private GitHub Package Registry.  |
 
-3. Open the Actions tab, select the **Build and Deploy** action and choose to run the workflow. The workflow will build the necessary container images, push them to your private Github Package Registry and deploy the necessary Azure services along with two Container Apps for the respective services.
+3. Go to the [Build and Deploy (DEV)](../../actions/workflows/build-and-push-dev.yaml) action and run the workflow. The workflow will build the necessary container images, push them to your private Github Package Registry and deploy the necessary Azure services along with two Container Apps for the respective services.
 
 4. Once the GitHub Actions have completed successfully, navigate to the [Azure Portal](https://portal.azure.com) and select the resource group you created. Open the `album-viewer` container app and browse to the FQDN displayed on the overview blade. You should see the sample application up and running.
 

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e-tests",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.28.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
+      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "dev": true
+    },
+    "node_modules/playwright-core": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
+  "dependencies": {
+    "@playwright/test": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
+      }
+    },
+    "@types/node": {
+      "version": "18.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
+      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "dev": true
+    },
+    "playwright-core": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
+      "dev": true
+    }
+  }
+}

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.28.1"
+  }
+}

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -1,0 +1,108 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.baseUrl,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on',
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+export default config;

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -30,7 +30,11 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: './results/junit.xml' }],
+    ['html', { outputFolder: './results/html' }],
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -39,8 +39,6 @@ const config: PlaywrightTestConfig = {
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.baseUrl,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on',

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -32,8 +32,8 @@ const config: PlaywrightTestConfig = {
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['list'],
-    ['junit', { outputFile: './results/junit.xml' }],
-    ['html', { outputFolder: './results/html' }],
+    ['junit', { outputFile: './test-results/junit.xml' }],
+    ['html', { outputFolder: './playwright-report/html' }],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/e2e-tests/tests/api.spec.ts
+++ b/e2e-tests/tests/api.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect, request } from '@playwright/test';
+
+test('Should return albums.', async ({ request }) => {
+    // Make a GET request to the albums API
+    const albums = await request.get(process.env.apiUrl + 'albums');    
+    // Verify that the response is OK
+    await expect(albums.ok()).toBeTruthy();
+    //  For each album, assert that the response contains the expected properties
+    const respBody = JSON.parse(await albums.text())
+    for (let i = 0; i < respBody.length; ++i)
+    { 
+        await expect(respBody[i].id).toBeTruthy()
+        await expect(respBody[i].title).toBeTruthy()
+        await expect(respBody[i].artist).toBeTruthy()
+        await expect(respBody[i].price).toBeTruthy()
+        await expect(respBody[i].image_url).toBeTruthy()
+    }
+});

--- a/e2e-tests/tests/api.spec.ts
+++ b/e2e-tests/tests/api.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, request } from '@playwright/test';
 
 test('Should return albums.', async ({ request }) => {
     // Make a GET request to the albums API
-    const albums = await request.get(process.env.apiUrl + 'albums');    
+    const albums = await request.get(process.env.apiUrl + '/albums');    
     // Verify that the response is OK
     await expect(albums.ok()).toBeTruthy();
     //  For each album, assert that the response contains the expected properties

--- a/e2e-tests/tests/viewer.spec.ts
+++ b/e2e-tests/tests/viewer.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  // Go to viewer app before each test case
+  await page.goto('');
+});
+
+test('Should display viewer app.', async ({ page }) => {
+  // Verify that the page title is correct
+  await expect(page.locator('h1')).toContainText('Azure Container Apps Albums');
+  // Verify Greatest hits div is present
+  await expect(page.getByText('Greatest Hits')).toBeTruthy();
+  // Verify each menu item is clickable
+  await page.getByRole('button', { name: 'Docs' }).click();
+  await page.getByRole('button', { name: 'Public Roadmap' }).click();
+  await page.getByRole('button', { name: 'Discord' }).click();
+  await page.getByRole('button', { name: 'Mailing List' }).click();
+});
+
+test('Should display albums correctly.', async ({ page }) => {
+  // Loop through each album
+  const albums = page.locator('.item');
+  const count = await albums.count();
+  for (let i = 0; i < count; ++i)
+  { 
+    const album = await albums.nth(i);
+    // Verify album title is present
+    const albumTitle = await album.locator('.album-title'); 
+    await expect(albumTitle).toBeTruthy();
+    // Verify album image is present
+    const albumImage = await album.locator('img'); 
+    await expect(albumImage).toBeTruthy();
+  }
+});

--- a/e2e-tests/tests/viewer.spec.ts
+++ b/e2e-tests/tests/viewer.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   // Go to viewer app before each test case
-  await page.goto('');
+  await page.goto(process.env.baseUrl);
 });
 
 test('Should display viewer app.', async ({ page }) => {


### PR DESCRIPTION
Added [Playwright](https://playwright.dev/) tests to validate the Album Viewer web app and Album API. A GHA step gets the dynamically generated container app FQDN's via az cli and sets them as env variables for the test scripts to use. Currently set up to test across Chromium, Firefox, and WebKit, and upload the [HTML report](https://playwright.dev/docs/test-reporters#html-reporter) (self contained site) as an artifact for post-mortem troubleshooting, including the [trace](https://playwright.dev/docs/trace-viewer-intro) on every run.

To run tests locally:
- `cd e2e-tests`
- Run `npm install`
- Set env variable for `baseUrl` to FQDN of viewer container app: 
```bash
    export baseUrl='paste-the-value'
 ```
- Set env variable for `apiUrl` to FQDN of viewer container app
```bash
    export apiUrl='paste-the-value'
 ```
- Install the [Playwright VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) to run tests with a single click

OR
- [run via CLI](https://playwright.dev/docs/running-tests) using `npx playwright test`
